### PR TITLE
[WAZO-789] celery: spawn multiple workers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends:
  python3-kombu,
  python3-marshmallow,
  python3-psycopg2,
+ python3-setproctitle,
  python3-sqlalchemy,
  python3-stevedore,
  python3-yaml,

--- a/etc/wazo-webhookd/config.yml
+++ b/etc/wazo-webhookd/config.yml
@@ -32,6 +32,8 @@ celery:
     exchange_name: celery-webhookd
     queue_name: celery-webhookd
     worker_pid_file: /var/run/wazo-webhookd/celery-worker.pid
+    worker_min: 3
+    worker_max: 10
 
 # consul connection informations
 consul:

--- a/integration_tests/suite/test_celery.py
+++ b/integration_tests/suite/test_celery.py
@@ -1,0 +1,37 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import re
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries
+)
+from xivo_test_helpers import until
+
+from .helpers.base import (
+    BaseIntegrationTest,
+    VALID_TOKEN
+)
+from .helpers.wait_strategy import NoWaitStrategy
+
+
+class TestCeleryWorks(BaseIntegrationTest):
+
+    asset = 'base'
+    wait_strategy = NoWaitStrategy()
+
+    def test_we_have_3_workers_by_default(self):
+        output = self.docker_exec(["ps", "-eo", "cmd"]).decode()
+
+        master_found = False
+        worker_count = 0
+        for line in output.split("\n"):
+            if re.match("\[celeryd: webhookd@.*:MainProcess\] .*", line):
+                master_found = True
+            elif re.match("\[celeryd: webhookd@.*:Worker-.\]", line):
+                worker_count += 1
+
+        assert_that(master_found, equal_to(True))
+        assert_that(worker_count, equal_to(3))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ flask-restful==0.3.5
 flask==1.0.2
 jinja2==2.10.1
 kombu==3.0.35
+setproctitle==1.1.10
 marshmallow==2.16.3
 netifaces==0.10.4
 psycopg2==2.6.2

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -39,6 +39,8 @@ _DEFAULT_CONFIG = {
         'exchange_name': 'celery-webhookd',
         'queue_name': 'celery-webhookd',
         'worker_pid_file': os.path.join(_PID_DIR, 'celery-worker.pid'),
+        'worker_min': 3,
+        'worker_max': 10,
     },
     'consul': {
         'scheme': 'https',


### PR DESCRIPTION
This change spawn between 3 to 10 celery workers.

It uses setproctitle to allow to name celery worker

