### PR TITLE
 Prepare repository for zuul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 build/
 dist/
+.tox
 *.egg-info/
 *.pyc
+.coverage
+coverage.xml
+nosetests.xml

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -11,6 +11,3 @@ https://github.com/wazo-pbx/xivo-test-helpers/archive/master.zip
 https://github.com/wazo-pbx/xivo-lib-python/archive/master.zip
 https://github.com/wazo-pbx/xivo-lib-rest-client/archive/master.zip
 https://github.com/wazo-pbx/mockserver-client-python/archive/default-exact.zip
-
-# for database tests
--e ..

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, pycodestyle, pylint
+envlist = py35,linters,pylint
 skipsdist = true
 
 [testenv]
+basepython = python3
 commands =
     nosetests --cover-package=wazo_webhookd --with-xunit --with-coverage --cover-xml --cover-erase wazo_webhookd
 deps =
@@ -15,18 +16,35 @@ deps =
     -rtest-requirements.txt
     coverage
 
-[testenv:pycodestyle]
+[testenv:black]
+skip_install = true
+deps = black
+commands = black --skip-string-normalization .
+
+[testenv:linters]
+skip_install = true
 basepython = python3
-# E501: line too long (80 chars)
+deps = flake8
+       flake8-colors
+       black
 commands =
-    -sh -c 'pycodestyle --ignore=E501 wazo_webhookd > pycodestyle.txt'
+  # Don't fail on black failure for now
+  -black --skip-string-normalization --check .
+  flake8
+
+[testenv:integration]
+skip_install = true
 deps =
-    pycodestyle
+    -e .
+    -rintegration_tests/test-requirements.txt
+commands =
+    sh -c "cd integration_tests && make test-setup"
+    sh -c "cd integration_tests && nosetests -v {posargs}"
 whitelist_externals =
     sh
 
 [testenv:pylint]
-basepython = python3
+skip_install = true
 commands =
     -sh -c 'pylint --rcfile=/usr/share/xivo-ci/pylintrc wazo_webhookd > pylint.txt'
 deps =
@@ -35,3 +53,10 @@ deps =
     pylint
 whitelist_externals =
     sh
+
+[flake8]
+exclude = .tox,.eggs,alembic
+show-source = true
+ignore = E501, W503
+max-line-length = 88
+application-import-names = wazo_webhookd

--- a/wazo_webhookd/celery.py
+++ b/wazo_webhookd/celery.py
@@ -37,7 +37,7 @@ class CoreCeleryWorker():
             #   celeryd: webhookd@<hostname>:MainProcess
             #   celeryd: webhookd@<hostname>:Worker-*
             '--hostname', 'webhookd@%h',
-            '--autoscale',  "{},{}".format(
+            '--autoscale', "{},{}".format(
                 app.conf['CELERY_WORKER_MAX'],
                 app.conf['CELERY_WORKER_MIN']
             ),

--- a/wazo_webhookd/rest_api.py
+++ b/wazo_webhookd/rest_api.py
@@ -73,8 +73,8 @@ class CoreRestApi(object):
 
 class ErrorCatchingResource(Resource):
     method_decorators = ([mallow_helpers.handle_validation_exception,
-                          rest_api_helpers.handle_api_exception] +
-                         Resource.method_decorators)
+                          rest_api_helpers.handle_api_exception]
+                         + Resource.method_decorators)
 
 
 class AuthResource(ErrorCatchingResource):

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,0 +1,41 @@
+- job:
+    name: tox-integration
+    parent: tox
+    description: |
+      Run integration tests.
+
+      Uses tox with the ``integration`` environment.
+    vars:
+      tox_envlist: integration
+    nodeset:
+      nodes:
+        - name: test-node
+          label: debian9-vm
+
+- project:
+    check:
+      jobs:
+        - tox-linters:
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: runc-debian-buster
+        - tox-py35:
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: runc-debian-stretch
+        - tox-integration
+    gate:
+      jobs:
+        - tox-linters:
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: runc-debian-buster
+        - tox-py35:
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: runc-debian-stretch
+        - tox-integration


### PR DESCRIPTION
This adds the zuul configuration and add two tox targets to run in zuul:

* linters: that run flake8 and black (but without enforcing for now)
* integration: that run integration tests
