### PR TITLE
Fix issues that make webhookd stop processing messages

### DIFF
--- a/wazo_webhookd/bus.py
+++ b/wazo_webhookd/bus.py
@@ -106,18 +106,28 @@ class CoreBusConsumer(kombu.mixins.ConsumerMixin):
         return self._is_running
 
     def subscribe_to_event_names(self, uuid, event_names, user_uuid, wazo_uuid, callback):
+        if uuid is None:
+            raise RuntimeError("uuid must be set")
+        elif not event_names:
+            raise RuntimeError("event_names must be set")
         logger.debug('Subscribing new callback to events %s (uuid: %s)', event_names, uuid)
         queue = kombu.Queue(exclusive=True, bindings=self._create_bindings(event_names, user_uuid, wazo_uuid))
         consumer = kombu.Consumer(channel=None, queues=queue, callbacks=[callback])
         self._new_consumers.append((uuid, consumer))
 
     def change_subscription(self, uuid, event_names, user_uuid, wazo_uuid, callback):
+        if uuid is None:
+            raise RuntimeError("uuid must be set")
+        elif not event_names:
+            raise RuntimeError("event_names must be set")
         logger.debug('Changing subscription for callback (uuid: %s)', uuid)
         queue = kombu.Queue(exclusive=True, bindings=self._create_bindings(event_names, user_uuid, wazo_uuid))
         consumer = kombu.Consumer(channel=None, queues=queue, callbacks=[callback])
         self._updated_consumers.append((uuid, consumer))
 
     def unsubscribe_from_event_names(self, uuid):
+        if uuid is None:
+            raise RuntimeError("uuid must be set")
         logger.debug('Unsubscribing callback (uuid: %s)', uuid)
         self._stale_consumers.append(uuid)
 

--- a/wazo_webhookd/bus.py
+++ b/wazo_webhookd/bus.py
@@ -7,7 +7,6 @@ import kombu.mixins
 
 from collections import deque
 from contextlib import contextmanager
-from xivo.pubsub import Pubsub
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +14,6 @@ logger = logging.getLogger(__name__)
 class CoreBusConsumer(kombu.mixins.ConsumerMixin):
 
     def __init__(self, global_config):
-        self._all_events_pubsub = Pubsub()
         self._is_running = False
         self.connection = None
 

--- a/wazo_webhookd/plugins/subscription/service.py
+++ b/wazo_webhookd/plugins/subscription/service.py
@@ -91,6 +91,7 @@ class SubscriptionService(object):
         with self.rw_session() as session:
             new_subscription = Subscription(**subscription)
             session.add(new_subscription)
+            session.flush()
             self.pubsub.publish('created', new_subscription)
             return new_subscription
 

--- a/wazo_webhookd/plugins/subscription/service.py
+++ b/wazo_webhookd/plugins/subscription/service.py
@@ -22,11 +22,15 @@ from .exceptions import NoSuchSubscription
 
 class SubscriptionService(object):
 
+    # NOTE(sileht): We share the pubsub object, so plugin that instanciate
+    # another service (like push mobile) will continue work.
+
+    pubsub = Pubsub()
+
     def __init__(self, config):
         engine = create_engine(config['db_uri'])
         self._Session = scoped_session(sessionmaker())
         self._Session.configure(bind=engine)
-        self.pubsub = Pubsub()
 
     @contextmanager
     def rw_session(self):


### PR DESCRIPTION
flush sqlachemy session to generate the sub uuid
Add safeguard to the bus methods
Ensure all SubscriptionService use the same pubsub bus
bus: ack and requeue rabbitmq messages

Closes: [WAZO-824]

[WAZO-824]: https://wazo-dev.atlassian.net/browse/WAZO-824