### PR TITLE
Ensure we use python3 alembic

### DIFF
--- a/debian/wazo-webhookd.postinst
+++ b/debian/wazo-webhookd.postinst
@@ -31,7 +31,7 @@ case "$1" in
 
         wazo-webhookd-init-db --user postgres
         echo "Upgrading wazo-webhookd database ..."
-        (cd $ALEMBIC_INI_PATH && alembic -c alembic.ini upgrade head)
+        (cd $ALEMBIC_INI_PATH && python3 -m alembic.config -c alembic.ini upgrade head)
 
         if [[ -z "${previous_version}" ]]; then
             ln -sf /etc/nginx/locations/https-available/$DAEMONNAME \


### PR DESCRIPTION
Alembic binary is linked ot python2, sqlalchemy-utils is not installed
on python2, so alembix upgrade fail by default.

Anyways, we should use the python version that the software uses for
alembic too to avoid side-effect due to py2/py3 differences.

This change does that.