### PR TITLE
Pull request for WAZO-794-fixed-encoding-bugs

### DIFF
--- a/wazo_webhookd/services/helpers.py
+++ b/wazo_webhookd/services/helpers.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class HookExpectedError(Exception):
     def __init__(self, detail):
         self.detail = detail
-        super(HookRetry, self).__init__()
+        super(HookExpectedError, self).__init__()
 
 
 class HookRetry(Exception):


### PR DESCRIPTION
hook helpers: always decode request bodies
Use correct base class for HookExpectedError