### PR TITLE
Pull request for WAZO-935-fix-bus-startup

### DIFF
--- a/wazo_webhookd/bus.py
+++ b/wazo_webhookd/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -109,7 +109,8 @@ class CoreBusConsumer(kombu.mixins.ConsumerMixin):
         if uuid is None:
             raise RuntimeError("uuid must be set")
         elif not event_names:
-            raise RuntimeError("event_names must be set")
+            logger.warning("subscription `%s` doesn't have event_names set", uuid)
+            return
         logger.debug('Subscribing new callback to events %s (uuid: %s)', event_names, uuid)
         queue = kombu.Queue(exclusive=True, bindings=self._create_bindings(event_names, user_uuid, wazo_uuid))
         consumer = kombu.Consumer(channel=None, queues=queue, callbacks=[callback])
@@ -119,7 +120,8 @@ class CoreBusConsumer(kombu.mixins.ConsumerMixin):
         if uuid is None:
             raise RuntimeError("uuid must be set")
         elif not event_names:
-            raise RuntimeError("event_names must be set")
+            logger.warning("subscription `%s` doesn't have event_names set", uuid)
+            return
         logger.debug('Changing subscription for callback (uuid: %s)', uuid)
         queue = kombu.Queue(exclusive=True, bindings=self._create_bindings(event_names, user_uuid, wazo_uuid))
         consumer = kombu.Consumer(channel=None, queues=queue, callbacks=[callback])

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -47,7 +47,6 @@ class Service:
                          '{}/{}'.format(tenant_uuid, user_uuid)),
                 'service': 'mobile',
                 'events': [
-                    'call_created',
                     'chatd_user_room_message_created',
                     'call_push_notification',
                     'user_voicemail_message_created'
@@ -114,8 +113,7 @@ class Service:
         # tenant_uuid = subscription.get('events_tenant_uuid')
         if (event['data'].get('user_uuid') == user_uuid
                 # and event['data']['tenant_uuid'] == tenant_uuid
-                and event['name'] in ['chatd_user_room_message_created',
-                                      'call_created']):
+                and event['name'] == 'chatd_user_room_message_created'):
             return
 
         data, external_config = cls.get_external_token(config, user_uuid)


### PR DESCRIPTION
Don't fail to start the bus when subscription doesn't have event names set
Remove used event

API allows to have an empty list while the bus code doesn't. 