### PR TITLE
[WAZ0-966] Fix payload received for text and voicemail push notification

### DIFF
--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -157,7 +157,7 @@ class PushNotification(object):
         return self._send_notification(
             'voicemailReceived',
             'New voicemail',
-            'From: {}'.format(data['items']['message']['caller_id_num']),
+            'From: {}'.format(data['message']['caller_id_num']),
             'wazo-notification-voicemail',
             data,
         )
@@ -165,8 +165,8 @@ class PushNotification(object):
     def messageReceived(self, data):
         return self._send_notification(
             'messageReceived',
-            data['items']['alias'],
-            data['items']['content'],
+            data['alias'],
+            data['content'],
             'wazo-notification-chat',
             data,
         )


### PR DESCRIPTION
For example with test message :
```json
{
	"room": {
		"uuid": "ac33c8ae-e2a9-4035-8298-d11bbbf842bc"
	},
	"tenant_uuid": "007ca8d5-d361-42de-a0ed-8680105596b0",
	"user_uuid": "d53ae345-e9c2-4f9f-a5e7-227cfce060b3",
	"uuid": "d92668d3-a9af-42de-8712-f9b99c3a1a5c",
	"content": "coin",
	"created_at": "2019-07-29T17:08:19.448269+00:00",
	"alias": "Emmanuel 2 Quentin 2",
	"wazo_uuid": "6cd695d2-cdb9-4444-8b2d-27425ab85fa8"
}
```

There is no `items` key, I've tested on `demo` with this code without any issue.