### PR TITLE
Fix alembic in Dockerfile-db

### DIFF
--- a/contribs/docker/Dockerfile-db
+++ b/contribs/docker/Dockerfile-db
@@ -7,7 +7,7 @@ RUN true \
     && python3 setup.py install \
     && pg_start \
     && wazo-webhookd-init-db --user postgres \
-    && (cd /usr/src/wazo-webhookd && alembic -c alembic.ini upgrade head) \
+    && (cd /usr/src/wazo-webhookd && python3 -m alembic.config -c alembic.ini upgrade head) \
     && pg_stop \
     && true
 USER postgres


### PR DESCRIPTION
We want to use alembic in python3, but the alembic provided by the system is in python2.