### PR TITLE
http callback: fix handling of body charset.

### DIFF
--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -69,7 +69,7 @@ TEST_SUBSCRIPTION_CONTENT_TYPE = {
         'url': 'http://third-party-http:1080/test',
         'method': 'post',
         'body': 'keỳ: vàlue',
-        'content_type': 'text/yaml',
+        'content_type': 'text/yaml; charset=utf-8',
     },
     'events': ['trigger'],
 }
@@ -503,7 +503,10 @@ class TestHTTPCallback(BaseIntegrationTest):
                     'path': '/test',
                     'body': '{"ke\\u00fd": "v\\u00e0lue"}',
                     'headers': [
-                        {'name': 'Content-Type', 'values': ['application/json']}
+                        {
+                            'name': 'Content-Type',
+                            'values': ['application/json; charset=utf-8'],
+                        }
                     ],
                 }
             ),
@@ -603,7 +606,9 @@ class TestHTTPCallback(BaseIntegrationTest):
                     'method': 'POST',
                     'path': '/test',
                     'body': 'keỳ: vàlue',
-                    'headers': [{'name': 'Content-Type', 'values': ['text/yaml']}],
+                    'headers': [
+                        {'name': 'Content-Type', 'values': ['text/yaml; charset=utf-8']}
+                    ],
                 }
             ),
             tries=10,

--- a/wazo_webhookd/services/http/plugin.py
+++ b/wazo_webhookd/services/http/plugin.py
@@ -1,6 +1,7 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import cgi
 import json
 import logging
 import requests
@@ -33,9 +34,7 @@ class Service:
             'wazo_uuid': event['origin_uuid'],
         }
 
-        url = options['url']
-        template = url
-        url = Environment().from_string(template).render(values)
+        url = Environment().from_string(options['url']).render(values)
 
         if subscription['owner_user_uuid'] and cls.url_is_localhost(url):
             # some services only listen on 127.0.0.1 and should not be accessible to users
@@ -46,19 +45,24 @@ class Service:
             )
             return
 
-        content_type = options.get('content_type')
-
         body = options.get('body')
-        if body:
-            template = body
-            body = Environment().from_string(template).render(values)
-            body = body.encode('utf-8')
-        else:
-            body = json.dumps(event['data'])
-            content_type = 'application/json'
 
-        if content_type:
-            headers['Content-Type'] = content_type
+        if body:
+            content_type = options.get('content_type', 'text/plain')
+            # NOTE(sileht): parse_header will drop any erroneous options
+            ct_mimetype, ct_options = cgi.parse_header(content_type)
+            ct_options.setdefault('charset', 'utf-8')
+            data = Environment().from_string(body).render(values)
+        else:
+            ct_mimetype = 'application/json'
+            ct_options = {'charset': 'utf-8'}
+            data = json.dumps(event['data'])
+
+        data = data.encode(ct_options['charset'])
+
+        headers['Content-Type'] = "{}; {}".format(
+            ct_mimetype, "; ".join(map("=".join, ct_options.items()))
+        )
 
         verify = options.get('verify_certificate')
         if verify:
@@ -69,7 +73,7 @@ class Service:
             with requests.request(
                 options['method'],
                 url,
-                data=body,
+                data=data,
                 verify=verify,
                 headers=headers,
                 timeout=REQUESTS_TIMEOUT,


### PR DESCRIPTION
The RFC default charset is us-ascii, but if not provide we encode it in
UTF8. Everybody agree that UTF8 is better default now, but web server
must respect the RFC and use us-acsii if charset is not provided.

Infortunatly mockserver was not respecting the RFC and was decoding the
body as utf8 instead of us-ascii, making some test to pass instead of
failing.

This change ensure we always have a charset. If the subscription does
not have it we uses utf-8, if subscription have it we encode the body
with the provided one.

So servers will always known what the encoding is.